### PR TITLE
Fixes on image check and go 1.16

### DIFF
--- a/xgo.go
+++ b/xgo.go
@@ -318,6 +318,7 @@ func compile(image string, config *ConfigFlags, flags *BuildFlags, folder string
 			log.Printf("INFO: Using vendored Go module dependencies")
 		}
 	} else {
+		args = append(args, []string{"-e", "GO111MODULE=off"}...)
 		for i := 0; i < len(locals); i++ {
 			args = append(args, []string{"-v", fmt.Sprintf("%s:%s:ro", locals[i], mounts[i])}...)
 		}

--- a/xgo.go
+++ b/xgo.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"go/build"
@@ -102,10 +101,8 @@ func main() {
 			image = fmt.Sprintf("%s:%s", *dockerRepo, *goVersion)
 		}
 		// Check that all required images are available
-		found, err := checkDockerImage(image)
+		found := checkDockerImage(image)
 		switch {
-		case err != nil:
-			log.Fatalf("ERROR: Failed to check docker image availability: %v.", err)
 		case !found:
 			fmt.Println("not found!")
 			if err := pullDockerImage(image); err != nil {
@@ -202,13 +199,10 @@ func checkDocker() error {
 }
 
 // Checks whether a required docker image is available locally.
-func checkDockerImage(image string) (bool, error) {
+func checkDockerImage(image string) bool {
 	log.Printf("INFO: Checking for required docker image %s... ", image)
-	out, err := exec.Command("docker", "images", "--no-trunc").Output()
-	if err != nil {
-		return false, err
-	}
-	return bytes.Contains(out, []byte(image)), nil
+	err := exec.Command("docker", "image", "inspect", image).Run()
+	return err == nil
 }
 
 // Pulls an image from the docker registry.


### PR DESCRIPTION
Image check always fails even if the image exists, because the output of `docker images --no-trunc` will never match something like `name:tag`

`docker image inspect` is a more stable way to check image existance, just by checking the exit code.

___

go 1.16 enables go modules by default, so we have to explicitly set `GO111MODULE=off` on non-module path