### PR TITLE
fix: add git config safe dir

### DIFF
--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -76,6 +76,8 @@ elif [[ "$USEMODULES" == true ]]; then
     echo "Go modules are enabled but go.mod was not found in the source folder."
     exit 10
   fi
+  # set git safe directory, ref: CVE-2022-24765
+  git config --global --add safe.directory /source
   # Change into the repo/source folder
   cd /source
   echo "Building /source/go.mod..."


### PR DESCRIPTION
Hi, Sir. I add `git config --global --add safe.directory` before build, it maybe could fix #60 .

reference:
https://github.com/actions/checkout/issues/760
https://github.blog/2022-04-12-git-security-vulnerability-announced/
