### PR TITLE
Go 1.21.6, 1.21.7, 1.21.8, 1.22.0, 1.22.1

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,8 +22,8 @@ env:
   DOCKERHUB_SLUG: crazymax/xgo
   GHCR_SLUG: ghcr.io/crazy-max/xgo
   PLATFORMS: linux/amd64,linux/arm64
-  LATEST_CURRENT: 1.21.5
-  LATEST_PREVIOUS: 1.20.12
+  LATEST_CURRENT: 1.22.1
+  LATEST_PREVIOUS: 1.21.8
 
 jobs:
   prepare:
@@ -58,25 +58,17 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - 1.20.0
-          - 1.20.1
-          - 1.20.2
-          - 1.20.3
-          - 1.20.4
-          - 1.20.5
-          - 1.20.6
-          - 1.20.7
-          - 1.20.8
-          - 1.20.9
-          - 1.20.10
-          - 1.20.11
-          - 1.20.12
           - 1.21.0
           - 1.21.1
           - 1.21.2
           - 1.21.3
           - 1.21.4
           - 1.21.5
+          - 1.21.6
+          - 1.21.7
+          - 1.21.8
+          - 1.22.0
+          - 1.22.1
     steps:
       -
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - 1.21.5
-          - 1.20.12
+          - 1.22.1
+          - 1.21.8
         case:
           - c
           - cpp

--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -99,7 +99,7 @@ else
 
   # Otherwise download the canonical import path (may fail, don't allow failures beyond)
   echo "Fetching main repository $1..."
-  GO111MODULE=off go get -v -d "$1"
+  GHQ_ROOT=$GOPATH_ROOT ghq get "$1"
   set -e
 
   cd "$GOPATH_ROOT/$1"

--- a/tests/c/go.mod
+++ b/tests/c/go.mod
@@ -1,0 +1,3 @@
+module tests/c
+
+go 1.21

--- a/tests/cpp/go.mod
+++ b/tests/cpp/go.mod
@@ -1,0 +1,3 @@
+module tests/cpp
+
+go 1.21


### PR DESCRIPTION
I tried to follow last update, hopefully everything covered

also removed go 1.20 version to not exceed 360 minutes building time of github actions

this needs https://github.com/crazy-max/goxx/pull/70