### PR TITLE
chore: upgrade golang to latest supported images

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,20 +27,21 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - "1.24.0"
-          - "1.24.1"
-          - "1.24.2"
-          - "1.24.3"
-          - "1.24.4"
-          - "1.24.5"
-          - "1.24.6"
-          - "1.24.7"
           - "1.25.0"
           - "1.25.1"
+          - "1.25.2"
+          - "1.25.3"
+          - "1.25.4"
+          - "1.25.5"
+          - "1.25.6"
+          - "1.25.7"
+          - "1.25.8"
+          - "1.26.0"
+          - "1.26.1"
     with:
       go_version: ${{ matrix.go_version }}
-      latest_current: "1.25.1"
-      latest_previous: "1.24.7"
+      latest_current: "1.26.1"
+      latest_previous: "1.25.8"
     secrets:
       docker_username: ${{ secrets.DOCKER_USERNAME }}
       docker_password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-          - "1.25.1"
-          - "1.24.7"
+          - "1.26.1"
+          - "1.25.8"
         case:
           - c
           - cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION="1.25.1"
+ARG GO_VERSION="1.26.1"
 ARG OSXCROSS_VERSION="12.3"
 ARG GHQ_VERSION="1.6.1"
 ARG XX_VERSION="1.7.0"
@@ -8,7 +8,7 @@ ARG ALPINE_VERSION="3.22"
 ARG PLATFORMS="linux/386 linux/amd64 linux/arm64 linux/arm/v5 linux/arm/v6 linux/arm/v7 linux/mips linux/mipsle linux/mips64 linux/mips64le linux/ppc64le linux/riscv64 linux/s390x windows/386 windows/amd64"
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine${ALPINE_VERSION} AS base
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine${ALPINE_VERSION} AS base
 COPY --from=xx / /
 ENV CGO_ENABLED=0
 RUN apk add --no-cache file git


### PR DESCRIPTION
This is missing 1.25.9 and 1.26.2 as they are missing from crazy-max/goxx at the moment.

Refs #163