### PR TITLE
harden xgo-build cleanup state

### DIFF
--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -31,6 +31,7 @@ set -e
 
 USR_LOCAL_CONTENTS=""
 USR_LOCAL_SNAPSHOT=false
+ORIGINAL_PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
 
 function cleanup {
   local status=$?
@@ -66,6 +67,14 @@ function cleanup {
   exit "$status"
 }
 trap cleanup EXIT
+
+function reset_pkg_config_path {
+  if [ "$ORIGINAL_PKG_CONFIG_PATH" == "" ]; then
+    unset PKG_CONFIG_PATH
+  else
+    export PKG_CONFIG_PATH="$ORIGINAL_PKG_CONFIG_PATH"
+  fi
+}
 
 # Define a function that figures out the binary extension
 function extension {
@@ -274,6 +283,7 @@ for TARGET in $TARGETS; do
     fi
     ext=$(extension linux)
     (set -x ; CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5t" CGO_CXXFLAGS="-march=armv5t" go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-arm-5$ext" $PACK_RELPATH)
+    reset_pkg_config_path
     if [ "$(semver compare "$GO_VERSION" "1.5.0")" -ge 0 ]; then
       echo "Cleaning up Go runtime for linux/arm-5..."
       rm -rf /usr/local/go/pkg/linux_arm
@@ -295,6 +305,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension linux)
       (set -x ; CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-arm-6$ext" $PACK_RELPATH)
+      reset_pkg_config_path
 
       echo "Cleaning up Go runtime for linux/arm-6..."
       rm -rf /usr/local/go/pkg/linux_arm
@@ -316,6 +327,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension linux)
       (set -x ; CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-arm-7$ext" $PACK_RELPATH)
+      reset_pkg_config_path
 
       echo "Cleaning up Go runtime for linux/arm-7..."
       rm -rf /usr/local/go/pkg/linux_arm
@@ -334,6 +346,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension linux)
       (set -x ; CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-arm64$ext" $PACK_RELPATH)
+      reset_pkg_config_path
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips64" ]); then
@@ -352,6 +365,7 @@ for TARGET in $TARGETS; do
         fi
         ext=$(extension linux)
         (set -x ; CC=mips64-linux-gnuabi64-gcc CXX=mips64-linux-gnuabi64-g++ GOOS=linux GOARCH=mips64 CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-mips64$ext" $PACK_RELPATH)
+        reset_pkg_config_path
       fi
     fi
   fi
@@ -371,6 +385,7 @@ for TARGET in $TARGETS; do
         fi
         ext=$(extension linux)
         (set -x ; CC=mips64el-linux-gnuabi64-gcc CXX=mips64el-linux-gnuabi64-g++ GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-mips64le$ext" $PACK_RELPATH)
+        reset_pkg_config_path
       fi
     fi
   fi
@@ -390,6 +405,7 @@ for TARGET in $TARGETS; do
         fi
         ext=$(extension linux)
         (set -x ; CC=mips-linux-gnu-gcc CXX=mips-linux-gnu-g++ GOOS=linux GOARCH=mips CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-mips$ext" $PACK_RELPATH)
+        reset_pkg_config_path
       fi
     fi
   fi
@@ -409,6 +425,7 @@ for TARGET in $TARGETS; do
         fi
         ext=$(extension linux)
         (set -x ; CC=mipsel-linux-gnu-gcc CXX=mipsel-linux-gnu-g++ GOOS=linux GOARCH=mipsle CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-mipsle$ext" $PACK_RELPATH)
+        reset_pkg_config_path
       fi
     fi
   fi
@@ -425,6 +442,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension linux)
       (set -x ; CC=powerpc64le-linux-gnu-gcc CXX=powerpc64le-linux-gnu-g++ GOOS=linux GOARCH=ppc64le CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-ppc64le$ext" $PACK_RELPATH)
+      reset_pkg_config_path
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "riscv64" ]); then
@@ -440,6 +458,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension linux)
       (set -x ; CC=riscv64-linux-gnu-gcc CXX=riscv64-linux-gnu-g++ GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-riscv64$ext" $PACK_RELPATH)
+      reset_pkg_config_path
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "s390x" ]); then
@@ -455,6 +474,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension linux)
       (set -x ; CC=s390x-linux-gnu-gcc CXX=s390x-linux-gnu-g++ GOOS=linux GOARCH=s390x CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-s390x$ext" $PACK_RELPATH)
+      reset_pkg_config_path
     fi
   fi
   # Check and build for Windows targets
@@ -484,6 +504,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension windows)
       (set -x ; CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $H $LD" $R $BM -o "/build/$NAME-windows-amd64$R$ext" $PACK_RELPATH)
+      reset_pkg_config_path
     fi
     if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then
       echo "Compiling for windows$PLATFORM_SUFFIX/386..."
@@ -495,6 +516,7 @@ for TARGET in $TARGETS; do
       fi
       ext=$(extension windows)
       (set -x ; CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$V $H $LD" $BM -o "/build/$NAME-windows-386$ext" $PACK_RELPATH)
+      reset_pkg_config_path
     fi
 #    FIXME: gcc_libinit_windows.c:8:10: fatal error: 'windows.h' file not found
 #    if [ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]; then

--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -29,8 +29,7 @@
 
 set -e
 
-USR_LOCAL_CONTENTS=""
-USR_LOCAL_SNAPSHOT=false
+USR_LOCAL_SNAPSHOT=""
 ORIGINAL_PKG_CONFIG_PATH="$PKG_CONFIG_PATH"
 
 function cleanup {
@@ -38,27 +37,19 @@ function cleanup {
   local cleanup_status=0
   set +e
 
-  if [ -d /deps ] || [ "$USR_LOCAL_SNAPSHOT" == "true" ]; then
+  if [ -d /deps ] || [ "$USR_LOCAL_SNAPSHOT" != "" ]; then
     echo "Cleaning up build environment..."
   fi
 
   rm -rf /deps || cleanup_status=$?
 
-  if [ "$USR_LOCAL_SNAPSHOT" == "true" ]; then
-    for dir in $(ls /usr/local); do
-      keep=0
-
-      # Check against original folder contents
-      for old in $USR_LOCAL_CONTENTS; do
-        if [ "$old" == "$dir" ]; then
-          keep=1
-        fi
-      done
-      # Delete anything freshly generated
-      if [ "$keep" == "0" ]; then
-        rm -rf "/usr/local/$dir" || cleanup_status=$?
+  if [ "$USR_LOCAL_SNAPSHOT" != "" ]; then
+    while IFS= read -r path; do
+      if ! grep -Fxq "$path" "$USR_LOCAL_SNAPSHOT"; then
+        rm -rf "$path" || cleanup_status=$?
       fi
-    done
+    done < <(find /usr/local -mindepth 1 -depth)
+    rm -f "$USR_LOCAL_SNAPSHOT" || cleanup_status=$?
   fi
 
   if [ "$status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
@@ -206,8 +197,8 @@ done
 DEPS_ARGS=($ARGS)
 
 # Save the contents of the pre-build /usr/local folder for post cleanup
-USR_LOCAL_CONTENTS=$(ls /usr/local)
-USR_LOCAL_SNAPSHOT=true
+USR_LOCAL_SNAPSHOT=$(mktemp)
+find /usr/local -mindepth 1 > "$USR_LOCAL_SNAPSHOT"
 
 # Configure some global build parameters
 NAME=$(basename $1/$PACK)

--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -27,6 +27,46 @@
 #   GO_VERSION        - Bootstrapped version of Go to disable uncupported targets
 #   EXT_GOPATH        - GOPATH elements mounted from the host filesystem
 
+set -e
+
+USR_LOCAL_CONTENTS=""
+USR_LOCAL_SNAPSHOT=false
+
+function cleanup {
+  local status=$?
+  local cleanup_status=0
+  set +e
+
+  if [ -d /deps ] || [ "$USR_LOCAL_SNAPSHOT" == "true" ]; then
+    echo "Cleaning up build environment..."
+  fi
+
+  rm -rf /deps || cleanup_status=$?
+
+  if [ "$USR_LOCAL_SNAPSHOT" == "true" ]; then
+    for dir in $(ls /usr/local); do
+      keep=0
+
+      # Check against original folder contents
+      for old in $USR_LOCAL_CONTENTS; do
+        if [ "$old" == "$dir" ]; then
+          keep=1
+        fi
+      done
+      # Delete anything freshly generated
+      if [ "$keep" == "0" ]; then
+        rm -rf "/usr/local/$dir" || cleanup_status=$?
+      fi
+    done
+  fi
+
+  if [ "$status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
+    exit "$cleanup_status"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
 # Define a function that figures out the binary extension
 function extension {
   if [ "$FLAG_BUILDMODE" == "archive" ] || [ "$FLAG_BUILDMODE" == "c-archive" ]; then
@@ -67,7 +107,6 @@ if [ "$EXT_GOPATH" != "" ]; then
   # If local builds are requested, inject the sources
   echo "Building locally $1..."
   export GOPATH=$GOPATH:$EXT_GOPATH
-  set -e
 
   # Find and change into the package folder
   cd "$(go list -e -f '{{.Dir}}' $1)"
@@ -100,8 +139,7 @@ else
 
   # Otherwise download the canonical import path (may fail, don't allow failures beyond)
   echo "Fetching main repository $1..."
-  GHQ_ROOT=$GOPATH_ROOT ghq get "$1"
-  set -e
+  GHQ_ROOT=$GOPATH_ROOT ghq get "$1" || true
 
   cd "$GOPATH_ROOT/$1"
 
@@ -160,6 +198,7 @@ DEPS_ARGS=($ARGS)
 
 # Save the contents of the pre-build /usr/local folder for post cleanup
 USR_LOCAL_CONTENTS=$(ls /usr/local)
+USR_LOCAL_SNAPSHOT=true
 
 # Configure some global build parameters
 NAME=$(basename $1/$PACK)
@@ -529,24 +568,5 @@ for TARGET in $TARGETS; do
     # Remove any automatically injected deployment target vars
     unset MACOSX_DEPLOYMENT_TARGET
 
-  fi
-done
-
-# Clean up any leftovers for subsequent build invocations
-echo "Cleaning up build environment..."
-rm -rf /deps
-
-for dir in $(ls /usr/local); do
-  keep=0
-
-  # Check against original folder contents
-  for old in $USR_LOCAL_CONTENTS; do
-    if [ "$old" == "$dir" ]; then
-      keep=1
-    fi
-  done
-  # Delete anything freshly generated
-  if [ "$keep" == "0" ]; then
-    rm -rf "/usr/local/$dir"
   fi
 done

--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -148,6 +148,7 @@ else
 fi
 
 # Download all the C dependencies
+rm -rf /deps
 mkdir /deps
 DEPS=($DEPS) && for dep in "${DEPS[@]}"; do
   if [ "${dep##*.}" == "tar" ]; then cat "/deps-cache/$(basename $dep)" | tar -C /deps -x; fi


### PR DESCRIPTION
The script now resets stale dependency extraction state, removes generated `/usr/local` files recursively, restores `PKG_CONFIG_PATH` after target-specific builds, and avoids masking the original build failure with cleanup failures.