### PR TITLE
fix platform-specific build settings

### DIFF
--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -377,7 +377,7 @@ for TARGET in $TARGETS; do
       else
         echo "Compiling for linux/mips64le..."
         CC=mips64el-linux-gnuabi64-gcc CXX=mips64el-linux-gnuabi64-g++ HOST=mips64el-linux-gnuabi64 PREFIX=/usr/mips64el-linux-gnuabi64 xgo-build-deps /deps "${DEPS_ARGS[@]}"
-        export PKG_CONFIG_PATH=/usr/mips64le-linux-gnuabi64/lib/pkgconfig
+        export PKG_CONFIG_PATH=/usr/mips64el-linux-gnuabi64/lib/pkgconfig
 
         if [[ "$USEMODULES" == false ]]; then
           CC=mips64el-linux-gnuabi64-gcc CXX=mips64el-linux-gnuabi64-g++ GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go get $V $X $TP $VCS "${T[@]}" --ldflags="$V $LD" $PACK_RELPATH
@@ -417,7 +417,7 @@ for TARGET in $TARGETS; do
       else
         echo "Compiling for linux/mipsle..."
         CC=mipsel-linux-gnu-gcc CXX=mipsel-linux-gnu-g++ HOST=mipsel-linux-gnu PREFIX=/usr/mipsel-linux-gnu xgo-build-deps /deps "${DEPS_ARGS[@]}"
-        export PKG_CONFIG_PATH=/usr/mipsle-linux-gnu/lib/pkgconfig
+        export PKG_CONFIG_PATH=/usr/mipsel-linux-gnu/lib/pkgconfig
 
         if [[ "$USEMODULES" == false ]]; then
           CC=mipsel-linux-gnu-gcc CXX=mipsel-linux-gnu-g++ GOOS=linux GOARCH=mipsle CGO_ENABLED=1 go get $V $X $TP $VCS "${T[@]}" --ldflags="$V $LD" $PACK_RELPATH

--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -571,7 +571,7 @@ for TARGET in $TARGETS; do
           CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go get $V $X $TP $VCS "${T[@]}" --ldflags="$LDSTRIP $V $LD" $PACK_RELPATH
         fi
         ext=$(extension darwin)
-        (set -x ; CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP $VCS $TP $MOD "${T[@]}" --ldflags="$LDSTRIP $V $LD" $R $BM -o "/build/$NAME-darwin-arm64$R$ext" $PACK_RELPATH)
+        (set -x ; CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP $VCS $MOD "${T[@]}" --ldflags="$LDSTRIP $V $LD" $R $BM -o "/build/$NAME-darwin-arm64$R$ext" $PACK_RELPATH)
       fi
     fi
     if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then

--- a/rootfs/usr/local/bin/xgo-build
+++ b/rootfs/usr/local/bin/xgo-build
@@ -487,6 +487,7 @@ for TARGET in $TARGETS; do
     fi
 
     MAJOR=$(echo $PLATFORM | cut -d '.' -f 1)
+    MINOR=0
     if [ "${PLATFORM/.}" != "$PLATFORM" ] ; then
       MINOR=$(echo $PLATFORM | cut -d '.' -f 2)
     fi


### PR DESCRIPTION
The little-endian MIPS targets now use pkg-config paths that match their GNU triplet prefixes, Windows target parsing resets the minor version for each target, and the Darwin arm64 build command no longer passes the trimpath placeholder twice.